### PR TITLE
Add Teller Token (TELLER) BEP20 metadata and logo

### DIFF
--- a/blockchains/smartchain/assets/blockchains/smartchain/assets/0x4A3a61ba6e98b53e8104c91b0127f68596588391/info.json
+++ b/blockchains/smartchain/assets/blockchains/smartchain/assets/0x4A3a61ba6e98b53e8104c91b0127f68596588391/info.json
@@ -1,0 +1,14 @@
+{
+  "name": "Teller Token",
+  "symbol": "TELLER",
+  "type": "BEP20",
+  "decimals": 18,
+  "status": "active",
+  "id": "0x4A3a61ba6e98b53e8104c91b0127f68596588391",
+  "logo": "https://raw.githubusercontent.com/Wapabrasil/assets/master/blockchains/smartchain/assets/0x4A3a61ba6e98b53e8104c91b0127f68596588391/logo.png",
+  "links": {
+    "website": "https://wapabrasil.org",
+    "telegram": "https://t.me/wapabrasil",
+    "twitter": "https://twitter.com/wapabrasil"
+  }
+}


### PR DESCRIPTION
Inclusão do token Teller (TELLER) na rede Binance Smart Chain (BEP20) com os arquivos obrigatórios:

Contrato: 0x4A3a61ba6e98b53e8104c91b0127f68596588391

Símbolo: TELLER

Nome: Teller Token

Decimais: 18

Logo: logo.png

Metadados: info.json